### PR TITLE
feat: HU-01 | Gestión de videojuegos - CRUD completo

### DIFF
--- a/backend/src/main/java/com/gamelist/gamelist_api/controller/VideojuegoController.java
+++ b/backend/src/main/java/com/gamelist/gamelist_api/controller/VideojuegoController.java
@@ -1,0 +1,53 @@
+package com.gamelist.gamelist_api.controller;
+
+import com.gamelist.gamelist_api.model.Videojuego;
+import com.gamelist.gamelist_api.service.VideojuegoService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/videojuegos")
+@CrossOrigin(origins = "*")
+public class VideojuegoController {
+
+    private final VideojuegoService videojuegoService;
+
+    public VideojuegoController(VideojuegoService videojuegoService) {
+        this.videojuegoService = videojuegoService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Videojuego>> listar() {
+        return ResponseEntity.ok(videojuegoService.listarVideojuegos());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Videojuego> obtener(@PathVariable Long id) {
+        return ResponseEntity.ok(videojuegoService.obtenerPorId(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<Videojuego> crear(@Valid @RequestBody Videojuego videojuego) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(videojuegoService.crearVideojuego(videojuego));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Videojuego> actualizar(@PathVariable Long id, @Valid @RequestBody Videojuego videojuego) {
+        return ResponseEntity.ok(videojuegoService.actualizarVideojuego(id, videojuego));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        videojuegoService.eliminarVideojuego(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/categoria/{categoriaId}")
+    public ResponseEntity<List<Videojuego>> listarPorCategoria(@PathVariable Long categoriaId) {
+        return ResponseEntity.ok(videojuegoService.listarPorCategoria(categoriaId));
+    }
+}

--- a/backend/src/main/java/com/gamelist/gamelist_api/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/gamelist/gamelist_api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.gamelist.gamelist_api.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleNotFound(ResourceNotFoundException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now().toString());
+        body.put("status", 404);
+        body.put("error", "Not Found");
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidation(MethodArgumentNotValidException ex) {
+        Map<String, Object> body = new HashMap<>();
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError fe : ex.getBindingResult().getFieldErrors()) {
+            errors.put(fe.getField(), fe.getDefaultMessage());
+        }
+        body.put("timestamp", LocalDateTime.now().toString());
+        body.put("status", 400);
+        body.put("error", "Bad Request");
+        body.put("fields", errors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now().toString());
+        body.put("status", 400);
+        body.put("error", "Bad Request");
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+}

--- a/backend/src/main/java/com/gamelist/gamelist_api/exception/ResourceNotFoundException.java
+++ b/backend/src/main/java/com/gamelist/gamelist_api/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.gamelist.gamelist_api.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/gamelist/gamelist_api/model/Videojuego.java
+++ b/backend/src/main/java/com/gamelist/gamelist_api/model/Videojuego.java
@@ -1,0 +1,50 @@
+package com.gamelist.gamelist_api.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+@Entity
+@Table(name = "videojuego")
+public class Videojuego {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "El título es obligatorio")
+    private String titulo;
+
+    private String plataforma;
+
+    @NotNull(message = "El año es obligatorio")
+    private Integer anio;
+
+    @NotBlank(message = "El estado es obligatorio")
+    @Pattern(
+        regexp = "PENDIENTE|JUGANDO|TERMINADO|FAVORITO",
+        message = "El estado debe ser: PENDIENTE, JUGANDO, TERMINADO o FAVORITO"
+    )
+    private String estado;
+
+    @ManyToOne
+    @JoinColumn(name = "categoria_id")
+    private Categoria categoria;
+
+    public Videojuego() {}
+
+    public Long getId() { return id; }
+    public String getTitulo() { return titulo; }
+    public String getPlataforma() { return plataforma; }
+    public Integer getAnio() { return anio; }
+    public String getEstado() { return estado; }
+    public Categoria getCategoria() { return categoria; }
+
+    public void setId(Long id) { this.id = id; }
+    public void setTitulo(String titulo) { this.titulo = titulo; }
+    public void setPlataforma(String plataforma) { this.plataforma = plataforma; }
+    public void setAnio(Integer anio) { this.anio = anio; }
+    public void setEstado(String estado) { this.estado = estado; }
+    public void setCategoria(Categoria categoria) { this.categoria = categoria; }
+}

--- a/backend/src/main/java/com/gamelist/gamelist_api/service/VideojuegoService.java
+++ b/backend/src/main/java/com/gamelist/gamelist_api/service/VideojuegoService.java
@@ -1,0 +1,52 @@
+package com.gamelist.gamelist_api.service;
+
+import com.gamelist.gamelist_api.exception.ResourceNotFoundException;
+import com.gamelist.gamelist_api.model.Videojuego;
+import com.gamelist.gamelist_api.repository.VideojuegoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class VideojuegoService {
+
+    private final VideojuegoRepository videojuegoRepository;
+
+    public VideojuegoService(VideojuegoRepository videojuegoRepository) {
+        this.videojuegoRepository = videojuegoRepository;
+    }
+
+    public List<Videojuego> listarVideojuegos() {
+        return videojuegoRepository.findAll();
+    }
+
+    public Videojuego crearVideojuego(Videojuego videojuego) {
+        return videojuegoRepository.save(videojuego);
+    }
+
+    public Videojuego obtenerPorId(Long id) {
+        return videojuegoRepository.findById(id)
+            .orElseThrow(() -> new ResourceNotFoundException("Videojuego no encontrado con id: " + id));
+    }
+
+    public Videojuego actualizarVideojuego(Long id, Videojuego nuevo) {
+        Videojuego existente = obtenerPorId(id);
+        existente.setTitulo(nuevo.getTitulo());
+        existente.setPlataforma(nuevo.getPlataforma());
+        existente.setAnio(nuevo.getAnio());
+        existente.setEstado(nuevo.getEstado());
+        if (nuevo.getCategoria() != null) {
+            existente.setCategoria(nuevo.getCategoria());
+        }
+        return videojuegoRepository.save(existente);
+    }
+
+    public void eliminarVideojuego(Long id) {
+        obtenerPorId(id);
+        videojuegoRepository.deleteById(id);
+    }
+
+    public List<Videojuego> listarPorCategoria(Long categoriaId) {
+        return videojuegoRepository.findByCategoriaId(categoriaId);
+    }
+}


### PR DESCRIPTION
## HU-01 | Gestión de videojuegos

**Issue:** closes #1
**Sprint:** 1
**Rama:** `feature/sprint1-backend-videojuegos`

## Cambios implementados

- `GET /api/videojuegos` — lista todos los juegos con categoría y plataforma
- `POST /api/videojuegos` — crea juego con validación de campos obligatorios (`@Valid`)
- `PUT /api/videojuegos/{id}` — actualiza datos de un juego existente
- `DELETE /api/videojuegos/{id}` — elimina juego (cascade de reseñas en HU-06)
- `404` con JSON descriptivo cuando el ID no existe (`ResourceNotFoundException`)
- `400` con detalle del campo inválido cuando falla validación (`GlobalExceptionHandler`)
- Campo `estado` validado con `@Pattern`: solo acepta `PENDIENTE`, `JUGANDO`, `TERMINADO`, `FAVORITO`
- Prefijo `/api/videojuegos` en todos los endpoints

## Archivos nuevos / modificados

- `exception/ResourceNotFoundException.java` — excepción personalizada
- `exception/GlobalExceptionHandler.java` — manejo global 404 y 400 en JSON
- `model/Videojuego.java` — validaciones Bean Validation
- `service/VideojuegoService.java` — lanza excepción si ID no existe
- `controller/VideojuegoController.java` — ResponseEntity con status codes correctos

## Criterios de aceptación

- [x] GET /api/videojuegos retorna lista de todos los juegos
- [x] POST /api/videojuegos crea juego con validación
- [x] PUT /api/videojuegos/{id} actualiza juego existente
- [x] DELETE /api/videojuegos/{id} elimina el juego
- [x] 404 con JSON descriptivo cuando el ID no existe
- [x] Estado solo acepta: PENDIENTE, JUGANDO, TERMINADO, FAVORITO

