### PR TITLE
feat: HU-14 | CI/CD y Kanban automation - closes #14

### DIFF
--- a/.github/workflows/kanban-automation.yml
+++ b/.github/workflows/kanban-automation.yml
@@ -22,13 +22,14 @@ jobs:
           script: |
             const issueNumber = context.payload.issue.number;
             const owner = context.repo.owner;
-            const repo = context.repo.repo;
             const projectNumber = parseInt('${{ vars.PROJECT_NUMBER }}') || 1;
 
-            // Buscar el proyecto del repositorio
-            const projectsQuery = `
-              query($owner: String!, $repo: String!, $number: Int!) {
-                repository(owner: $owner, name: $repo) {
+            console.log(`Issue #${issueNumber} asignado. Buscando en proyecto #${projectNumber} del usuario ${owner}...`);
+
+            // GitHub Projects v2 a nivel de USUARIO (no de repositorio)
+            const query = `
+              query($login: String!, $number: Int!) {
+                user(login: $login) {
                   projectV2(number: $number) {
                     id
                     fields(first: 20) {
@@ -53,30 +54,43 @@ jobs:
               }
             `;
 
-            const projectData = await github.graphql(projectsQuery, {
-              owner, repo, number: projectNumber
-            });
+            let projectData;
+            try {
+              projectData = await github.graphql(query, { login: owner, number: projectNumber });
+            } catch (err) {
+              console.error('Error consultando el proyecto:', err.message);
+              throw err;
+            }
 
-            const project = projectData.repository.projectV2;
+            const project = projectData?.user?.projectV2;
+            if (!project) {
+              console.error(`Proyecto #${projectNumber} no encontrado para el usuario ${owner}.`);
+              console.error('Verifica que PROJECT_NUMBER sea correcto y que el PROJECT_TOKEN tenga scope "project".');
+              throw new Error('Proyecto no encontrado');
+            }
+
             const statusField = project.fields.nodes.find(f => f.name === 'Status');
             if (!statusField) {
-              console.log('Campo Status no encontrado');
-              return;
+              console.error('Campo "Status" no encontrado. Campos disponibles:',
+                project.fields.nodes.map(f => f.name).join(', '));
+              throw new Error('Campo Status no encontrado');
             }
+
+            console.log('Opciones de Status:', statusField.options.map(o => o.name).join(', '));
 
             const inProgressOption = statusField.options.find(o =>
               o.name.toLowerCase() === 'in progress' || o.name.toLowerCase() === 'en progreso'
             );
             if (!inProgressOption) {
-              console.log('Opción In Progress no encontrada');
-              return;
+              console.error('Opción "In Progress" no encontrada.');
+              throw new Error('Opción In Progress no encontrada');
             }
 
             const item = project.items.nodes.find(i =>
               i.content && i.content.number === issueNumber
             );
             if (!item) {
-              console.log(`Issue #${issueNumber} no encontrado en el proyecto`);
+              console.error(`Issue #${issueNumber} no está en el proyecto. ¿Fue agregado al tablero?`);
               return;
             }
 
@@ -96,7 +110,7 @@ jobs:
               optionId: inProgressOption.id
             });
 
-            console.log(`✅ Issue #${issueNumber} movido a In Progress`);
+            console.log(`✅ Issue #${issueNumber} movido a "In Progress"`);
 
   # ─────────────────────────────────────────────
   # Al cerrar un PR merged → mueve card a "Done"
@@ -106,36 +120,38 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     steps:
-      - name: Obtener issues cerrados por el PR
-        id: get-issues
+      - name: Mover cards a Done
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PROJECT_TOKEN }}
           script: |
-            const prNumber = context.payload.pull_request.number;
             const owner = context.repo.owner;
-            const repo = context.repo.repo;
             const projectNumber = parseInt('${{ vars.PROJECT_NUMBER }}') || 1;
 
-            // Buscar issues vinculados al PR via el body (closes #N)
-            const prBody = context.payload.pull_request.body || '';
-            const commitMsg = context.payload.pull_request.title || '';
+            // Extraer issues referenciados con closes/fixes/resolves #N
+            const prBody  = context.payload.pull_request.body  || '';
+            const prTitle = context.payload.pull_request.title || '';
             const closePattern = /(?:closes?|fixes?|resolves?)\s+#(\d+)/gi;
             const issueNumbers = [];
             let match;
-            const combined = prBody + ' ' + commitMsg;
-            while ((match = closePattern.exec(combined)) !== null) {
-              issueNumbers.push(parseInt(match[1]));
+            for (const text of [prBody, prTitle]) {
+              while ((match = closePattern.exec(text)) !== null) {
+                issueNumbers.push(parseInt(match[1]));
+              }
             }
 
             if (issueNumbers.length === 0) {
-              console.log('No se encontraron issues vinculados al PR');
+              console.log('No se encontraron referencias closes #N en el PR. Nada que mover.');
               return;
             }
 
-            const projectData = await github.graphql(`
-              query($owner: String!, $repo: String!, $number: Int!) {
-                repository(owner: $owner, name: $repo) {
+            console.log(`Issues referenciados: ${issueNumbers.join(', ')}`);
+            console.log(`Buscando proyecto #${projectNumber} del usuario ${owner}...`);
+
+            // GitHub Projects v2 a nivel de USUARIO
+            const query = `
+              query($login: String!, $number: Int!) {
+                user(login: $login) {
                   projectV2(number: $number) {
                     id
                     fields(first: 20) {
@@ -158,17 +174,38 @@ jobs:
                   }
                 }
               }
-            `, { owner, repo, number: projectNumber });
+            `;
 
-            const project = projectData.repository.projectV2;
+            let projectData;
+            try {
+              projectData = await github.graphql(query, { login: owner, number: projectNumber });
+            } catch (err) {
+              console.error('Error consultando el proyecto:', err.message);
+              throw err;
+            }
+
+            const project = projectData?.user?.projectV2;
+            if (!project) {
+              console.error(`Proyecto #${projectNumber} no encontrado para el usuario ${owner}.`);
+              console.error('Verifica PROJECT_NUMBER y que PROJECT_TOKEN tenga scope "project".');
+              throw new Error('Proyecto no encontrado');
+            }
+
             const statusField = project.fields.nodes.find(f => f.name === 'Status');
-            const doneOption = statusField?.options.find(o =>
+            if (!statusField) {
+              console.error('Campo "Status" no encontrado. Campos:',
+                project.fields.nodes.map(f => f.name).join(', '));
+              throw new Error('Campo Status no encontrado');
+            }
+
+            console.log('Opciones de Status:', statusField.options.map(o => o.name).join(', '));
+
+            const doneOption = statusField.options.find(o =>
               o.name.toLowerCase() === 'done' || o.name.toLowerCase() === 'terminado'
             );
-
-            if (!statusField || !doneOption) {
-              console.log('Campo Status u opción Done no encontrados');
-              return;
+            if (!doneOption) {
+              console.error('Opción "Done" no encontrada.');
+              throw new Error('Opción Done no encontrada');
             }
 
             for (const issueNum of issueNumbers) {
@@ -176,7 +213,7 @@ jobs:
                 i.content && i.content.number === issueNum
               );
               if (!item) {
-                console.log(`Issue #${issueNum} no está en el proyecto`);
+                console.log(`Issue #${issueNum} no está en el proyecto, saltando...`);
                 continue;
               }
 
@@ -196,5 +233,5 @@ jobs:
                 optionId: doneOption.id
               });
 
-              console.log(`✅ Issue #${issueNum} movido a Done`);
+              console.log(`✅ Issue #${issueNum} movido a "Done"`);
             }


### PR DESCRIPTION
## HU-14 | CI/CD con Cloud Build y GitHub Actions

**Issue:** closes #14
**Sprint:** 3
**Rama:** `feature/sprint3-cicd`

> ⚠️ **Este PR debe mergearse ANTES que los demás** para que el workflow de Kanban quede activo en `development` y pueda mover las cards automáticamente al mergear los PRs siguientes.

## Cambios

- `.github/workflows/kanban-automation.yml` — mueve cards automáticamente:
  - Issue asignado → **In Progress**
  - PR mergeado con `closes #N` → **Done**
- `.github/workflows/deploy.yml` — build + deploy a Cloud Run en cada push a `main`
- `docs/HISTORIAS_USUARIO.md` y `docs/HISTORIAS_USUARIO1.md` — criterios completos con trazabilidad

## Fix incluido

- Corregido bug crítico: ahora consulta `user.projectV2` (proyecto de usuario) en vez de `repository.projectV2` (que siempre devolvía null)
- Logs de error detallados para facilitar debug en GitHub Actions

## Criterios de aceptación

- [x] cloudbuild.yaml para build de imagen Docker unificada
- [x] GitHub Actions workflow mueve cards del tablero Kanban automáticamente
- [x] Al asignar un issue, la card pasa a "In Progress"
- [x] Al cerrar un PR merged, la card pasa a "Done"
- [x] Cloud Run actualizado con la nueva imagen en cada deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)